### PR TITLE
给获取所有可合成的物品添加NBT信息

### DIFF
--- a/client/plugins/ae.lua
+++ b/client/plugins/ae.lua
@@ -239,13 +239,20 @@ function ae.getAllCraftables()
 
     local result = {}
     for _, item in pairs(items) do
-        if item.isCraftable then
-            table.insert(result, {
-                name = item.name,
-                label = item.label,
-                size = item.size,
-                damage = item.damage
-            })
+    if item.isCraftable then
+        local entry = {
+            name = item.name,
+            label = item.label,
+            size = item.size,
+            damage = item.damage
+        }
+        
+        if item.hasTag then
+            entry.hasTag = true
+            entry.tag = base64.encode(item.tag)
+        end
+        
+        table.insert(result, entry)
         end
     end
 


### PR DESCRIPTION
要获取带 NBT 的物品，只能通过获取全部物品来获得。

我在使用 QQ机器人 来对接你的后端,现在获取可合成物品，碰到液滴识别不出来问题,所以修改这里